### PR TITLE
Add professional Streamlit dashboard with year/month filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ dmypy.json
 *.db
 *.sqlite
 *.sqlite3
+
+# Playright mcp
+.playwright-mcp

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # E-Commerce Business Analytics
 
-A comprehensive e-commerce analytics solution with modular Python architecture for analyzing sales performance, product trends, geographic distribution, and customer satisfaction.
+A comprehensive e-commerce analytics solution with modular Python architecture for analyzing sales performance, product trends, geographic distribution, and customer satisfaction. Includes both a professional Streamlit dashboard and detailed Jupyter notebook analysis.
 
 ## Project Structure
 
 ```
 .
+├── dashboard.py                # Streamlit dashboard application
 ├── data_loader.py              # Data loading and cleaning module
 ├── business_metrics.py         # Business metrics calculation and visualization
 ├── EDA_Refactored.ipynb        # Main analysis notebook
@@ -22,6 +23,16 @@ A comprehensive e-commerce analytics solution with modular Python architecture f
 
 ## Features
 
+### Interactive Dashboard
+- **Professional Streamlit Interface**: Modern web-based dashboard with responsive design
+- **KPI Cards**: Total Revenue, Monthly Growth, Average Order Value, Total Orders with trend indicators
+- **Revenue Trend Chart**: Dual-period comparison with current vs previous year
+- **Top 10 Categories**: Bar chart with blue gradient showing product performance
+- **Geographic Map**: US choropleth showing revenue by state
+- **Satisfaction Analysis**: Delivery time vs review score correlation
+- **Customer Experience Cards**: Average delivery time and review score with stars
+
+### Jupyter Notebook Analysis
 - **Revenue Analysis**: Total revenue, year-over-year growth, monthly trends
 - **Product Performance**: Category-level analysis with revenue share
 - **Geographic Analysis**: State-level revenue distribution with interactive maps
@@ -45,6 +56,23 @@ pip install -r requirements.txt
 ```
 
 ## Usage
+
+### Running the Dashboard
+
+1. **Start the Streamlit dashboard:**
+```bash
+streamlit run dashboard.py
+```
+
+2. **Access the dashboard:**
+   - Open your browser to `http://localhost:8501`
+   - The dashboard will automatically open
+
+3. **Using the dashboard:**
+   - Select a year from the dropdown in the top-right corner
+   - View KPI cards with trend indicators (green = positive, red = negative)
+   - Interact with charts to explore data
+   - Hover over visualizations for detailed tooltips
 
 ### Running the Refactored Analysis
 
@@ -266,7 +294,7 @@ Available statuses: delivered, shipped, canceled, pending, processing, returned
 ### Common Issues
 
 **Issue**: `ModuleNotFoundError: No module named 'data_loader'`
-- **Solution**: Ensure you're running the notebook from the project root directory
+- **Solution**: Ensure you're running the notebook/dashboard from the project root directory
 
 **Issue**: `FileNotFoundError: ecommerce_data/orders_dataset.csv`
 - **Solution**: Verify the `DATA_PATH` configuration points to the correct directory
@@ -276,6 +304,14 @@ Available statuses: delivered, shipped, canceled, pending, processing, returned
 
 **Issue**: Plots not displaying
 - **Solution**: Ensure `%matplotlib inline` is executed and matplotlib is installed
+
+**Issue**: Dashboard won't start
+- **Solution**: Ensure Streamlit is installed: `pip install streamlit>=1.28.0`
+- **Solution**: Check Python version is 3.9 or higher
+
+**Issue**: Dashboard shows no data
+- **Solution**: Verify CSV files exist in `ecommerce_data/` directory
+- **Solution**: Ensure selected year exists in the dataset
 
 ## Performance Notes
 

--- a/business_metrics.py
+++ b/business_metrics.py
@@ -47,9 +47,13 @@ class BusinessMetricsCalculator:
         metrics['total_revenue'] = self.sales_data['price'].sum()
 
         # Average order value (AOV)
-        order_totals = self.sales_data.groupby('order_id')['price'].sum()
-        metrics['average_order_value'] = order_totals.mean()
-        metrics['median_order_value'] = order_totals.median()
+        if len(self.sales_data) > 0 and self.sales_data['order_id'].nunique() > 0:
+            order_totals = self.sales_data.groupby('order_id')['price'].sum()
+            metrics['average_order_value'] = order_totals.mean()
+            metrics['median_order_value'] = order_totals.median()
+        else:
+            metrics['average_order_value'] = 0
+            metrics['median_order_value'] = 0
 
         # Total orders
         metrics['total_orders'] = self.sales_data['order_id'].nunique()
@@ -58,13 +62,19 @@ class BusinessMetricsCalculator:
         metrics['total_items'] = len(self.sales_data)
 
         # Items per order
-        metrics['avg_items_per_order'] = metrics['total_items'] / metrics['total_orders']
+        metrics['avg_items_per_order'] = (
+            metrics['total_items'] / metrics['total_orders']
+            if metrics['total_orders'] > 0 else 0
+        )
 
         # Comparison metrics (YoY growth)
-        if comparison_data is not None:
+        if comparison_data is not None and len(comparison_data) > 0:
             prev_revenue = comparison_data['price'].sum()
             prev_orders = comparison_data['order_id'].nunique()
-            prev_aov = comparison_data.groupby('order_id')['price'].sum().mean()
+            if prev_orders > 0:
+                prev_aov = comparison_data.groupby('order_id')['price'].sum().mean()
+            else:
+                prev_aov = 0
 
             if prev_revenue > 0:
                 metrics['revenue_growth_pct'] = (

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,476 @@
+"""
+E-Commerce Business Analytics Dashboard
+
+A professional Streamlit dashboard for visualizing e-commerce business metrics
+including revenue trends, product performance, geographic distribution, and
+customer satisfaction.
+"""
+
+import streamlit as st
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+from datetime import datetime
+from data_loader import load_and_process_data
+from business_metrics import BusinessMetricsCalculator
+
+# Page configuration
+st.set_page_config(
+    page_title="E-Commerce Analytics Dashboard",
+    layout="wide",
+    initial_sidebar_state="collapsed"
+)
+
+# Custom CSS for professional styling
+st.markdown("""
+<style>
+    /* Main container */
+    .main > div {
+        padding-top: 2rem;
+    }
+
+    /* Metric cards */
+    [data-testid="stMetricValue"] {
+        font-size: 2rem;
+        font-weight: 600;
+    }
+
+    [data-testid="stMetricDelta"] {
+        font-size: 1rem;
+    }
+
+    /* Card styling */
+    .metric-card {
+        background-color: #ffffff;
+        padding: 1.5rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        height: 100%;
+    }
+
+    /* Header styling */
+    h1 {
+        color: #1f2937;
+        font-weight: 700;
+    }
+
+    /* Chart containers */
+    .chart-container {
+        background-color: #ffffff;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        height: 400px;
+    }
+
+    /* Bottom cards */
+    .bottom-card {
+        background-color: #ffffff;
+        padding: 2rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        text-align: center;
+        height: 200px;
+    }
+</style>
+""", unsafe_allow_html=True)
+
+
+@st.cache_data
+def load_data(data_path='ecommerce_data/'):
+    """Load and process e-commerce data with caching."""
+    loader, processed_data = load_and_process_data(data_path)
+    return loader, processed_data
+
+
+@st.cache_data
+def get_available_years(_loader):
+    """Get list of available years from the data."""
+    summary = _loader.get_data_summary()
+    return summary.get('years_available', [2023])
+
+
+def format_currency(value):
+    """Format large numbers as currency with K/M suffixes."""
+    if value >= 1_000_000:
+        return f"${value/1_000_000:.1f}M"
+    elif value >= 1_000:
+        return f"${value/1_000:.0f}K"
+    else:
+        return f"${value:.0f}"
+
+
+def format_number(value):
+    """Format large numbers with K/M suffixes."""
+    if value >= 1_000_000:
+        return f"{value/1_000_000:.1f}M"
+    elif value >= 1_000:
+        return f"{value/1_000:.0f}K"
+    else:
+        return f"{value:.0f}"
+
+
+def create_revenue_trend_chart(current_monthly, previous_monthly, current_year, previous_year):
+    """Create revenue trend line chart with current and previous period."""
+    fig = go.Figure()
+
+    # Previous period (dashed line) - only if data exists
+    if previous_monthly is not None and len(previous_monthly) > 0:
+        fig.add_trace(go.Scatter(
+            x=previous_monthly['month'],
+            y=previous_monthly['revenue'],
+            mode='lines',
+            name=f'{previous_year}',
+            line=dict(color='#93C5FD', width=2, dash='dash'),
+            hovertemplate='<b>%{x}</b><br>Revenue: $%{y:,.0f}<extra></extra>'
+        ))
+
+    # Current period (solid line)
+    fig.add_trace(go.Scatter(
+        x=current_monthly['month'],
+        y=current_monthly['revenue'],
+        mode='lines+markers',
+        name=f'{current_year}',
+        line=dict(color='#2563EB', width=3),
+        marker=dict(size=8),
+        hovertemplate='<b>%{x}</b><br>Revenue: $%{y:,.0f}<extra></extra>'
+    ))
+
+    fig.update_layout(
+        title="Revenue Trend",
+        xaxis_title="Month",
+        yaxis_title="Revenue",
+        hovermode='x unified',
+        showlegend=True,
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+        margin=dict(l=0, r=0, t=40, b=0),
+        height=350,
+        plot_bgcolor='white',
+        xaxis=dict(
+            showgrid=True,
+            gridcolor='#E5E7EB',
+            tickmode='linear',
+            tick0=1,
+            dtick=1
+        ),
+        yaxis=dict(
+            showgrid=True,
+            gridcolor='#E5E7EB',
+            tickformat='$,.0s'
+        )
+    )
+
+    return fig
+
+
+def create_category_chart(product_performance):
+    """Create top 10 categories bar chart with blue gradient."""
+    top_10 = product_performance.head(10).sort_values('revenue', ascending=True)
+
+    # Create color gradient (lighter for lower values)
+    colors = [f'rgba(37, 99, 235, {0.4 + (i/10)*0.6})' for i in range(len(top_10))]
+
+    fig = go.Figure(go.Bar(
+        x=top_10['revenue'],
+        y=top_10['category'],
+        orientation='h',
+        marker=dict(color=colors),
+        text=[format_currency(v) for v in top_10['revenue']],
+        textposition='outside',
+        hovertemplate='<b>%{y}</b><br>Revenue: $%{x:,.0f}<extra></extra>'
+    ))
+
+    fig.update_layout(
+        title="Top 10 Product Categories",
+        xaxis_title="Revenue",
+        yaxis_title="",
+        margin=dict(l=0, r=0, t=40, b=0),
+        height=350,
+        plot_bgcolor='white',
+        xaxis=dict(
+            showgrid=False,
+            tickformat='$,.0s'
+        ),
+        yaxis=dict(
+            showgrid=False
+        )
+    )
+
+    return fig
+
+
+def create_geographic_map(geo_performance):
+    """Create US choropleth map with blue gradient."""
+    fig = px.choropleth(
+        geo_performance,
+        locations='state',
+        color='revenue',
+        locationmode='USA-states',
+        scope='usa',
+        color_continuous_scale='Blues',
+        labels={'revenue': 'Revenue'}
+    )
+
+    fig.update_layout(
+        title="Revenue by State",
+        margin=dict(l=0, r=0, t=40, b=0),
+        height=350,
+        geo=dict(bgcolor='rgba(0,0,0,0)')
+    )
+
+    return fig
+
+
+def create_satisfaction_delivery_chart(sales_data):
+    """Create bar chart showing satisfaction vs delivery time."""
+    # Get unique orders
+    delivery_orders = sales_data[
+        ['order_id', 'delivery_days', 'review_score']
+    ].drop_duplicates()
+
+    # Categorize delivery speed
+    def categorize_delivery_speed(days):
+        if pd.isna(days):
+            return 'Unknown'
+        if days <= 3:
+            return '1-3 days'
+        elif days <= 7:
+            return '4-7 days'
+        else:
+            return '8+ days'
+
+    delivery_orders['delivery_category'] = delivery_orders['delivery_days'].apply(
+        categorize_delivery_speed
+    )
+
+    # Calculate average review by category
+    avg_by_category = delivery_orders.groupby('delivery_category')[
+        'review_score'
+    ].mean().reset_index()
+
+    # Order categories properly
+    category_order = ['1-3 days', '4-7 days', '8+ days']
+    avg_by_category = avg_by_category.set_index('delivery_category').reindex(category_order).reset_index()
+
+    fig = go.Figure(go.Bar(
+        x=avg_by_category['delivery_category'],
+        y=avg_by_category['review_score'],
+        marker=dict(color='#2563EB'),
+        text=[f'{v:.2f}' for v in avg_by_category['review_score']],
+        textposition='outside',
+        hovertemplate='<b>%{x}</b><br>Avg Review: %{y:.2f}<extra></extra>'
+    ))
+
+    fig.update_layout(
+        title="Average Review Score by Delivery Time",
+        xaxis_title="Delivery Time",
+        yaxis_title="Average Review Score",
+        margin=dict(l=0, r=0, t=40, b=0),
+        height=350,
+        plot_bgcolor='white',
+        yaxis=dict(
+            range=[0, 5],
+            showgrid=True,
+            gridcolor='#E5E7EB'
+        ),
+        xaxis=dict(
+            showgrid=False
+        )
+    )
+
+    return fig
+
+
+def main():
+    # Load data
+    loader, processed_data = load_data()
+    available_years = get_available_years(loader)
+
+    # Header with title and date range filter
+    col1, col2, col3 = st.columns([2, 1, 1])
+    with col1:
+        st.title("E-Commerce Business Analytics Dashboard")
+    with col2:
+        # Set default year to 2023 if available
+        sorted_years = sorted(available_years, reverse=True)
+        default_index = sorted_years.index(2023) if 2023 in sorted_years else 0
+
+        selected_year = st.selectbox(
+            "Select Year",
+            options=sorted_years,
+            index=default_index
+        )
+    with col3:
+        selected_month = st.selectbox(
+            "Select Month",
+            options=["All Months"] + [f"{i:02d} - {month}" for i, month in enumerate([
+                "January", "February", "March", "April", "May", "June",
+                "July", "August", "September", "October", "November", "December"
+            ], 1)],
+            index=0
+        )
+
+        # Convert month selection to filter value
+        month_filter = None if selected_month == "All Months" else int(selected_month.split(" - ")[0])
+
+    # Calculate comparison year
+    comparison_year = selected_year - 1
+
+    # Create datasets
+    sales_current = loader.create_sales_dataset(
+        year_filter=selected_year,
+        month_filter=month_filter,
+        status_filter='delivered'
+    )
+
+    # Check if comparison year has data
+    sales_comparison = None
+    if comparison_year in available_years:
+        sales_comparison = loader.create_sales_dataset(
+            year_filter=comparison_year,
+            month_filter=month_filter,
+            status_filter='delivered'
+        )
+
+    # Calculate metrics
+    calculator = BusinessMetricsCalculator(sales_current)
+
+    revenue_metrics = calculator.calculate_revenue_metrics(comparison_data=sales_comparison)
+    product_performance = calculator.analyze_product_performance()
+    geo_performance = calculator.analyze_geographic_performance()
+    delivery_metrics = calculator.analyze_delivery_performance()
+    satisfaction_metrics = calculator.analyze_customer_satisfaction()
+
+    # Monthly trends (only for full year analysis)
+    monthly_trends = None
+    monthly_trends_prev = None
+    if month_filter is None:
+        try:
+            monthly_trends = calculator.calculate_monthly_trends()
+            if sales_comparison is not None and len(sales_comparison) > 0:
+                calculator_comparison = BusinessMetricsCalculator(sales_comparison)
+                monthly_trends_prev = calculator_comparison.calculate_monthly_trends()
+        except:
+            pass
+
+    # Previous year delivery metrics
+    delivery_metrics_prev = None
+    if sales_comparison is not None and len(sales_comparison) > 0:
+        calculator_comparison = BusinessMetricsCalculator(sales_comparison)
+        delivery_metrics_prev = calculator_comparison.analyze_delivery_performance()
+
+    st.markdown("<br>", unsafe_allow_html=True)
+
+    # KPI Row - 4 cards
+    kpi_col1, kpi_col2, kpi_col3, kpi_col4 = st.columns(4)
+
+    with kpi_col1:
+        trend_value = revenue_metrics.get('revenue_growth_pct')
+        st.metric(
+            label="Total Revenue",
+            value=format_currency(revenue_metrics['total_revenue']),
+            delta=f"{trend_value:.2f}%" if trend_value is not None else None,
+            delta_color="normal" if (trend_value is not None and trend_value >= 0) else "inverse"
+        )
+
+    with kpi_col2:
+        # Monthly growth - average MoM growth
+        if monthly_trends is not None and len(monthly_trends) > 0:
+            avg_monthly_growth = monthly_trends['revenue_growth_pct'].mean()
+            if pd.notna(avg_monthly_growth):
+                st.metric(
+                    label="Monthly Growth",
+                    value=f"{avg_monthly_growth:.2f}%"
+                )
+            else:
+                st.metric(label="Monthly Growth", value="N/A")
+        else:
+            st.metric(label="Monthly Growth", value="N/A")
+
+    with kpi_col3:
+        aov_trend = revenue_metrics.get('aov_growth_pct')
+        st.metric(
+            label="Average Order Value",
+            value=format_currency(revenue_metrics['average_order_value']),
+            delta=f"{aov_trend:.2f}%" if aov_trend is not None else None,
+            delta_color="normal" if (aov_trend is not None and aov_trend >= 0) else "inverse"
+        )
+
+    with kpi_col4:
+        order_trend = revenue_metrics.get('order_growth_pct')
+        st.metric(
+            label="Total Orders",
+            value=format_number(revenue_metrics['total_orders']),
+            delta=f"{order_trend:.2f}%" if order_trend is not None else None,
+            delta_color="normal" if (order_trend is not None and order_trend >= 0) else "inverse"
+        )
+
+    st.markdown("<br>", unsafe_allow_html=True)
+
+    # Charts Grid - 2x2 layout
+    chart_row1_col1, chart_row1_col2 = st.columns(2)
+
+    with chart_row1_col1:
+        if monthly_trends is not None and len(monthly_trends) > 0:
+            revenue_chart = create_revenue_trend_chart(
+                monthly_trends, monthly_trends_prev, selected_year, comparison_year
+            )
+            st.plotly_chart(revenue_chart, use_container_width=True)
+        else:
+            st.info("Revenue trend chart is only available for full year analysis. Please select 'All Months'.")
+
+    with chart_row1_col2:
+        category_chart = create_category_chart(product_performance)
+        st.plotly_chart(category_chart, use_container_width=True)
+
+    chart_row2_col1, chart_row2_col2 = st.columns(2)
+
+    with chart_row2_col1:
+        geo_chart = create_geographic_map(geo_performance)
+        st.plotly_chart(geo_chart, use_container_width=True)
+
+    with chart_row2_col2:
+        satisfaction_chart = create_satisfaction_delivery_chart(sales_current)
+        st.plotly_chart(satisfaction_chart, use_container_width=True)
+
+    st.markdown("<br>", unsafe_allow_html=True)
+
+    # Bottom Row - 2 cards
+    bottom_col1, bottom_col2 = st.columns(2)
+
+    with bottom_col1:
+        # Calculate delivery time trend
+        current_delivery = delivery_metrics['avg_delivery_days']
+        delivery_trend_pct = None
+
+        if delivery_metrics_prev is not None:
+            prev_delivery = delivery_metrics_prev.get('avg_delivery_days')
+            if prev_delivery is not None and prev_delivery > 0:
+                delivery_trend_pct = ((current_delivery - prev_delivery) / prev_delivery * 100)
+
+        st.metric(
+            label="Average Delivery Time",
+            value=f"{current_delivery:.1f} days",
+            delta=f"{delivery_trend_pct:.2f}%" if delivery_trend_pct is not None else None,
+            delta_color="inverse" if (delivery_trend_pct is not None and delivery_trend_pct >= 0) else "normal"  # Lower is better
+        )
+
+    with bottom_col2:
+        avg_score = satisfaction_metrics['avg_review_score']
+        # Display stars
+        full_stars = int(avg_score)
+        stars_display = "⭐" * full_stars
+        if avg_score - full_stars >= 0.5:
+            stars_display += "⭐"
+
+        st.markdown(f"""
+        <div style='text-align: center; padding: 1rem;'>
+            <div style='font-size: 3rem; font-weight: 600; color: #1f2937;'>{avg_score:.2f}</div>
+            <div style='font-size: 2rem; margin: 0.5rem 0;'>{stars_display}</div>
+            <div style='font-size: 1rem; color: #6b7280;'>Average Review Score</div>
+        </div>
+        """, unsafe_allow_html=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ numpy>=1.24.0
 matplotlib>=3.7.0
 plotly>=5.14.0
 
+# Dashboard
+streamlit>=1.28.0
+
 # Jupyter notebook
 jupyter>=1.0.0
 ipykernel>=6.23.0


### PR DESCRIPTION
## Summary
This PR adds a professional Streamlit dashboard for interactive e-commerce data analysis with comprehensive filtering capabilities.

## Features Added

### Interactive Dashboard
- Modern web-based interface with responsive design
- **KPI Cards Row**: 
  - Total Revenue with YoY growth trend
  - Monthly Growth percentage
  - Average Order Value with trend indicator
  - Total Orders with trend indicator
  - Color-coded trends (green for positive, red for negative)

### Visualizations (2x2 Grid)
1. **Revenue Trend Chart**: Line chart comparing current year vs previous year (solid vs dashed lines)
2. **Top 10 Categories**: Horizontal bar chart with blue gradient
3. **Geographic Map**: US choropleth showing revenue by state
4. **Satisfaction Analysis**: Bar chart correlating delivery time with review scores

### Bottom Row Cards
- Average Delivery Time with trend indicator
- Review Score with star rating display

### Filtering Capabilities
- **Year Filter**: Dropdown to select analysis year (defaults to 2023)
- **Month Filter**: Dropdown to select specific month or "All Months"
- All metrics and charts update dynamically based on filters

## Bug Fixes
- Fixed TypeError when selecting years without comparison data (e.g., 2021)
- Fixed ZeroDivisionError when analyzing months with no orders
- Added safe handling for empty datasets in business_metrics.py
- Proper null checking for all trend calculations

## Technical Details
- Added streamlit>=1.28.0 to requirements.txt
- All charts use Plotly for interactivity
- Implements caching for performance (@st.cache_data)
- Professional CSS styling for cards and layouts
- Revenue values formatted with K/M suffixes for readability

## Testing
- ✅ Tested with all years (2021-2024)
- ✅ Tested with all months including empty data
- ✅ Verified no crashes on edge cases
- ✅ Confirmed trend indicators display correctly
- ✅ Validated all visualizations render properly

## Usage
```bash
streamlit run dashboard.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)